### PR TITLE
add await to user-facing callbacks

### DIFF
--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -48,7 +48,7 @@ const createWebhookHandler = (options: CreemOptions) => {
       switch (event.eventType) {
         case "checkout.completed":
           await onCheckoutCompleted(ctx, event, options);
-          options.onCheckoutCompleted?.({
+          await options.onCheckoutCompleted?.({
             webhookEventType: event.eventType,
             webhookId: event.id,
             webhookCreatedAt: event.created_at,
@@ -57,7 +57,7 @@ const createWebhookHandler = (options: CreemOptions) => {
           break;
 
         case "refund.created":
-          options.onRefundCreated?.({
+          await options.onRefundCreated?.({
             webhookEventType: event.eventType,
             webhookId: event.id,
             webhookCreatedAt: event.created_at,
@@ -66,7 +66,7 @@ const createWebhookHandler = (options: CreemOptions) => {
           break;
 
         case "dispute.created":
-          options.onDisputeCreated?.({
+          await options.onDisputeCreated?.({
             webhookEventType: event.eventType,
             webhookId: event.id,
             webhookCreatedAt: event.created_at,
@@ -76,11 +76,11 @@ const createWebhookHandler = (options: CreemOptions) => {
 
         case "subscription.active":
           await onSubscriptionActive(ctx, event, options);
-          options.onGrantAccess?.({
+          await options.onGrantAccess?.({
             reason: "subscription_active",
             ...event.object,
           });
-          options.onSubscriptionActive?.({
+          await options.onSubscriptionActive?.({
             webhookEventType: event.eventType,
             webhookId: event.id,
             webhookCreatedAt: event.created_at,
@@ -90,11 +90,11 @@ const createWebhookHandler = (options: CreemOptions) => {
 
         case "subscription.trialing":
           await onSubscriptionTrialing(ctx, event, options);
-          options.onGrantAccess?.({
+          await options.onGrantAccess?.({
             reason: "subscription_trialing",
             ...event.object,
           });
-          options.onSubscriptionTrialing?.({
+          await options.onSubscriptionTrialing?.({
             webhookEventType: event.eventType,
             webhookId: event.id,
             webhookCreatedAt: event.created_at,
@@ -104,7 +104,7 @@ const createWebhookHandler = (options: CreemOptions) => {
           break;
         case "subscription.canceled":
           await onSubscriptionCanceled(ctx, event, options);
-          options.onSubscriptionCanceled?.({
+          await options.onSubscriptionCanceled?.({
             webhookEventType: event.eventType,
             webhookId: event.id,
             webhookCreatedAt: event.created_at,
@@ -114,11 +114,11 @@ const createWebhookHandler = (options: CreemOptions) => {
 
         case "subscription.paid":
           await onSubscriptionPaid(ctx, event, options);
-          options.onGrantAccess?.({
+          await options.onGrantAccess?.({
             reason: "subscription_paid",
             ...event.object,
           });
-          options.onSubscriptionPaid?.({
+          await options.onSubscriptionPaid?.({
             webhookEventType: event.eventType,
             webhookId: event.id,
             webhookCreatedAt: event.created_at,
@@ -128,11 +128,11 @@ const createWebhookHandler = (options: CreemOptions) => {
 
         case "subscription.expired":
           await onSubscriptionExpired(ctx, event, options);
-          options.onRevokeAccess?.({
+          await options.onRevokeAccess?.({
             reason: "subscription_expired",
             ...event.object,
           });
-          options.onSubscriptionExpired?.({
+          await options.onSubscriptionExpired?.({
             webhookEventType: event.eventType,
             webhookId: event.id,
             webhookCreatedAt: event.created_at,
@@ -142,7 +142,7 @@ const createWebhookHandler = (options: CreemOptions) => {
 
         case "subscription.unpaid":
           await onSubscriptionUnpaid(ctx, event, options);
-          options.onSubscriptionUnpaid?.({
+          await options.onSubscriptionUnpaid?.({
             webhookEventType: event.eventType,
             webhookId: event.id,
             webhookCreatedAt: event.created_at,
@@ -152,7 +152,7 @@ const createWebhookHandler = (options: CreemOptions) => {
 
         case "subscription.update":
           await onSubscriptionUpdate(ctx, event, options);
-          options.onSubscriptionUpdate?.({
+          await options.onSubscriptionUpdate?.({
             webhookEventType: event.eventType,
             webhookId: event.id,
             webhookCreatedAt: event.created_at,
@@ -162,7 +162,7 @@ const createWebhookHandler = (options: CreemOptions) => {
 
         case "subscription.past_due":
           await onSubscriptionPastDue(ctx, event, options);
-          options.onSubscriptionPastDue?.({
+          await options.onSubscriptionPastDue?.({
             webhookEventType: event.eventType,
             webhookId: event.id,
             webhookCreatedAt: event.created_at,
@@ -172,11 +172,11 @@ const createWebhookHandler = (options: CreemOptions) => {
 
         case "subscription.paused":
           await onSubscriptionPaused(ctx, event, options);
-          options.onRevokeAccess?.({
+          await options.onRevokeAccess?.({
             reason: "subscription_paused",
             ...event.object,
           });
-          options.onSubscriptionPaused?.({
+          await options.onSubscriptionPaused?.({
             webhookEventType: event.eventType,
             webhookId: event.id,
             webhookCreatedAt: event.created_at,


### PR DESCRIPTION
# Pull Request

## 📝 Description

All user-facing callbacks (`onGrantAccess`, `onRevokeAccess`, `onCheckoutCompleted`, `onSubscriptionActive`, etc.) were called without await. Since these callbacks are typed to accept async functions, the returned Promises were silently dropped. In serverless runtimes (Cloudflare Workers, Vercel Edge), this means the Worker is terminated before any async work inside the callback completes which making async DB writes, API calls, etc. impossible.

## 🎯 Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or update

## 🧪 Testing

<!-- Describe how you tested your changes -->
Deployed a pnpm patch on Cloudflare workers.

### Manual Testing
- [ ] Tested in development environment
- [x] Tested with Better-Auth integration
- [x] Tested database mode (if applicable)
- [ ] Tested API mode (if applicable)
- [x] Tested webhooks (if applicable)

### Test Environment
- **Better-Auth Version**: 1.5.5
- **Framework**: Nuxt
- **Database**:  Cloudflare D1

## ✅ Checklist

<!-- Mark completed items with an 'x' -->

- [x] My code follows the project's coding guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added JSDoc comments to new functions/types
- [x] I have updated the README.md if needed
- [x] I have added examples if needed
- [x] The build passes (`npm run build`)
- [x] Type checking passes (`npm run typecheck`)

## 🎨 Code Quality

- [x] Code is properly formatted
- [x] No unnecessary console.logs or debug code
- [x] Error handling is appropriate
- [x] TypeScript types are accurate and complete
- [x] Code is DRY (Don't Repeat Yourself)

---

**Reviewer Guidelines:**
- Check that types are correct and complete
- Verify documentation is clear and accurate
- Ensure examples work as expected
- Test in a real Better-Auth project if possible