### PR TITLE
docs: mark repository as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # @creem_io/better-auth
 
+> [!WARNING]
+> **This repository is deprecated and no longer maintained.**
+>
+> Active development of `@creem_io/better-auth` has moved to the Creem monorepo:
+>
+> **👉 https://github.com/armitage-labs/creem/tree/main/packages/better-auth**
+>
+> Please open issues, pull requests, and discussions there. This repository will be archived soon.
+
+---
+
 Official Creem Better-Auth plugin for seamless payments and subscription management.
 
 ## ✨ Features


### PR DESCRIPTION
## Summary
- Adds a deprecation banner at the top of the README pointing users to the Creem monorepo (`armitage-labs/creem` → `packages/better-auth`), where active development has moved.
- Prepares the repo for archival by making it visually obvious to anyone landing here that they should go elsewhere for issues, PRs, and discussions.

## Test plan
- [x] README renders the GitHub admonition (`> [!WARNING]`) at the top
- [x] Link to the new location is correct: https://github.com/armitage-labs/creem/tree/main/packages/better-auth
- [x] Rest of the README is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)